### PR TITLE
PLATFORM-207 - SyphonX API extended to take in user param

### DIFF
--- a/api.ts
+++ b/api.ts
@@ -105,20 +105,23 @@ export class SyphonXApi {
     apiKey?: string;
     headers?: Record<string, string>;
     url: string;
+    user?: string;
 
     /**
      * Constructs a new instance of the SyphonX API.
      *
      * @param apiKey - The API key to authenticate with the SyphonX API.
      * @param url - The base URL of the SyphonX API. Defaults to the `defaultUrl`.
+     * @param user - The email address of the user interacting with the SyphonX API.
      */
-    constructor(apiKey?: string, url?: string) {
+    constructor(apiKey?: string, url?: string, user?: string) {
         this.apiKey = apiKey;
         if (apiKey)
             this.headers = { "Authorization": `Bearer ${this.apiKey}` };
         this.url = url || defaultUrl;
         if (this.url.endsWith("/"))
             this.url = this.url.slice(0, -1);
+        this.user = user;
     }
 
     /**
@@ -362,7 +365,8 @@ export class SyphonXApi {
         if (name.startsWith("/"))
             name = name.slice(1);
         const headers = this.headers;
-        const file = await request.json(`${this.url}/template/${name}?write`);
+        const options = !!this.user ? { method: "GET", headers: { user: this.user } } : { method: "GET", headers: {} };
+        const file = await request.json(`${this.url}/template/${name}?write`, options as request.RequestOptions);
         if (hash && hash !== file.hash)
             throw new ErrorMessage(`File ${name} has been modified since last save`);
         await request.putJson(file.url, content, { headers });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "syphonx-lib",
-  "version": "1.2.60",
+  "version": "1.2.61",
   "description": "Common utilities for building apps with SyphonX",
   "author": "Dave Templin <dtempx@gmail.com> (https://github.com/dtempx/)",
   "homepage": "https://github.com/dtempx/syphonx-lib",


### PR DESCRIPTION
https://pricespider.atlassian.net/browse/PLATFORM-207

- SyphonX API constructor now takes in user (email) param
- user will be passed with API's writes to GCP's cloud-storage